### PR TITLE
Query AWS SDK for metric filter to build useful search link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 ## CloudWatch Logs Slack Notitifation
-A Lambda function to process SNS topics tied to CloudWatch Logs metric filter alarms and post to Slack.
+A Lambda function to process SNS topics tied to CloudWatch Logs metric filter alarms and post to Slack. The slack message includes a button that links to the log group associated with the metric filter with the metric filter search parameters applied so you can view the relevant events that triggered the alarm.
 
 Requires an encrypted environment variable set in Lambda `SLACK_TOKENS`.
 See [the AWS documentation on encrypted variables](https://docs.aws.amazon.com/lambda/latest/dg/tutorial-env_console.html) for more details.
-
-Also, be sure to update the line `AWS.config.update({ region: 'us-west-2' });` to match your Lambda AWS region.
-
-Additionally, When setting up your Metric Filters, makes sure that the metric namespace matches the name of your log-group as we're using the filter Namespace from the alerts to build links to the log group for further details.


### PR DESCRIPTION
## Features Added
* Query Metric filter for log group name instead of depending on the namespace being identical to log group name
* Query Metric filter to get the query string to generate a more useful link that will take you to the log group with the query applied so you can see offending events.
* Convert raw text link to button to make simpler slack messages.