### PR TITLE
Use relative date for search URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ const AWS = require('aws-sdk');
 const encrypted = process.env['SLACK_TOKENS'];
 let decrypted;
 async function processEvent(event, context, callback) {
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setHours(startDate.getHours() - 1);
     const https = require('https');
     const util = require('util');
     const slackTokens = decrypted
@@ -24,12 +27,11 @@ async function processEvent(event, context, callback) {
     catch (err) {
         console.log(err);
     }
-
+    let logGroupName
     logGroupName = metricFiltersLookup.metricFilters[0].logGroupName
 
     const encodedFilter =  encodeURIComponent(encodeURIComponent(metricFiltersLookup.metricFilters[0].filterPattern));
-    const searchURL = 'https://' + AWS.config.region + '.console.aws.amazon.com/cloudwatch/home?region=' + AWS.config.region + '#logEventViewer:group=' + logGroupName + ';filter=' + encodedFilter + ';start=PT1H'
-    
+    const searchURL = 'https://' + AWS.config.region + '.console.aws.amazon.com/cloudwatch/home?region=' + AWS.config.region + '#logEventViewer:group=' + logGroupName + ';filter=' + encodedFilter + ';start=' + startDate + ';end=' + endDate
     const postData = {
         "channel": "#errors",
     };


### PR DESCRIPTION
## Features added
* Closes #3 - Grabs current time and adjusts minus 1 hour instead of simply setting a relative time in the link. This will make the links live and show correct date for each link sent to Slack.